### PR TITLE
docs: fix Quick Start example and config field names

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ edgeflow --help
 
 Create a file `my_config.ef` in the project root directory:
 
+> **Note:** You'll need an actual TensorFlow Lite model file (`.tflite`). You can also use `.h5`, `.onnx`, or `.keras` format models.
+
 ```
 model = "path/to/your/model.tflite"
 output = "optimized_model.tflite"

--- a/README.md
+++ b/README.md
@@ -74,19 +74,9 @@ edgeflow --help
 
 > **Note**: You may see a warning about missing 'dynamic_device_profiles'. This is expected and doesn't affect functionality.
 
-### 3. Run Example
+### 3. Create Your Own Config
 
-```bash
-# View the example configuration
-cat examples/quick_start.ef
-
-# Run the compiler (note: requires a .tflite model file)
-edgeflow examples/quick_start.ef
-```
-
-### 4. Create Your Own Config
-
-Create a file `my_config.ef`:
+Create a file `my_config.ef` in the project root directory:
 
 ```
 model = "path/to/your/model.tflite"
@@ -108,7 +98,7 @@ If you prefer not to install, set `PYTHONPATH`:
 
 ```bash
 export PYTHONPATH=$(pwd)/src
-python -m edgeflow.compiler.edgeflowc examples/quick_start.ef
+python -m edgeflow.compiler.edgeflowc my_config.ef
 ```
 
 ## Usage


### PR DESCRIPTION
- Removed reference to non-existent examples/quick_start.ef file
- Fixed config field names from 'model_path'/'output_path' to 'model'/'output' to match validator requirements
- Added clarification to create my_config.ef in project root directory

The README referenced examples/quick_start.ef which doesn't exist and would be ignored by .gitignore rules. Also, the example configs used 'model_path' and 'output_path' but the validator expects 'model' and 'output', causing validation failures for users following the docs.

Tested and verified config now loads successfully.